### PR TITLE
Make harvest_object.metadata_modified_date timezone naive

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -467,7 +467,7 @@ class SpatialHarvester(HarvesterBase):
 
         # Get document modified date
         try:
-            metadata_modified_date = dateutil.parser.parse(iso_values['metadata-date'])
+            metadata_modified_date = dateutil.parser.parse(iso_values['metadata-date']).replace(tzinfo=None)
         except ValueError:
             self._save_object_error('Could not extract reference date for object {0} ({1})'
                         .format(harvest_object.id, iso_values['metadata-date']), harvest_object, 'Import')


### PR DESCRIPTION
Not really sure if this breaks anything else, but it fixes the situation I explained in [issue #16](https://github.com/okfn/ckanext-spatial/issues/16)
