### PR TITLE
[#26] Fanstatic: don't bundle geojson_preview.js

### DIFF
--- a/ckanext/spatial/public/resource.config
+++ b/ckanext/spatial/public/resource.config
@@ -8,6 +8,10 @@ lte IE 8 =
 
 main = base/main
 
+[main]
+
+dont_bundle = js/geojson_preview.js
+
 [groups]
 
 dataset_map =


### PR DESCRIPTION
This fixes an issue that the markers (for points) were not showing up on
the maps in GeoJSON previews.

Fixes #26.
