### PR TITLE
add progress into the iso values

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -234,11 +234,14 @@ class SpatialHarvester(HarvesterBase):
             'coupled-resource',
             'contact-email',
             'frequency-of-update',
-            'progress',
             'spatial-data-service-type',
         ]:
             extras[name] = iso_values[name]
 
+        if len(iso_values.get('progress', [])):
+            extras['progress'] = iso_values['progress'][0]
+        else:
+            extras['progress'] = ''
 
         if len(iso_values.get('resource-type', [])):
             extras['resource-type'] = iso_values['resource-type'][0]

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -200,10 +200,14 @@ class GeminiHarvester(SpatialHarvester):
             'coupled-resource',
             'contact-email',
             'frequency-of-update',
-            'progress',
             'spatial-data-service-type',
         ]:
             extras[name] = gemini_values[name]
+
+        if len(iso_values.get('progress', [])):
+            extras['progress'] = iso_values['progress'][0]
+        else:
+            extras['progress'] = ''
 
         extras['resource-type'] = gemini_values['resource-type'][0]
 

--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -489,7 +489,7 @@ class ISODocument(MappedXmlDocument):
                 "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:status/gmd:MD_ProgressCode/text()",
                 "gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:status/gmd:MD_ProgressCode/text()",
             ],
-            multiplicity="0..1",
+            multiplicity="*",
         ),
         ISOElement(
             name="keyword-inspire-theme",

--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -329,6 +329,7 @@ class TestHarvest(HarvestFixtureBase):
             'spatial': u'{"type": "Polygon", "coordinates": [[[0.205857204, 54.529947158], [0.205857204, 61.06066944], [-8.97114288, 61.06066944], [-8.97114288, 54.529947158], [0.205857204, 54.529947158]]]}',
             # Other
             'coupled-resource': u'[]',
+            'progress': u'["completed"]',
             'dataset-reference-date': u'[{"type": "creation", "value": "2004-02"}, {"type": "revision", "value": "2006-07-03"}]',
             'frequency-of-update': u'irregular',
             'licence': u'["Reference and PSMA Only", "http://www.test.gov.uk/licenseurl"]',


### PR DESCRIPTION
Client requested to support the search on a to-be-added field (filter), to be called "progress" to enable keyword-value search as progress:planned or progress:completed. (progress:planned is how one would find Marketplace data)  The typical XML structure in a record looks like:  gmd:status  <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed">planned/gmd:MD_ProgressCode/gmd:status
