### PR TITLE
Add support for collection column in pycsw db

### DIFF
--- a/bin/ckan_pycsw.py
+++ b/bin/ckan_pycsw.py
@@ -84,7 +84,7 @@ def load(pycsw_config, ckan_url):
             gathered_records[result['id']] = {
                 'metadata_modified': result['metadata_modified'],
                 'harvest_object_id': result['extras']['harvest_object_id'],
-                'source': result['extras'].get('metadata_source'),
+                'source': result['extras'].get('metadata_source')
             }
             is_collection = True
             if 'collection_package_id' in result['extras']:


### PR DESCRIPTION
Recently we added filtering support in pycsw configuration, so CSW endpoint can actually "hide" records similar to what is done with CKAN collections.

In order to be able to replicate this functionality through ckanext-spatial, this fix is needed in order to create an extra boolean field in pycsw db.
