### PR TITLE
[#55] Allow CSW harvesters to define CQL filters (2nd try)

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -613,6 +613,8 @@ class SpatialHarvester(HarvesterBase):
         if config_str:
             self.source_config = json.loads(config_str)
             log.debug('Using config: %r', self.source_config)
+        else:
+            self.source_config = {}
 
     def _get_validator(self):
         '''

--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -86,10 +86,13 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
 
         guids_in_db = set(guid_to_package_id.keys())
 
+        # extract cql filter if any
+        cql = self.source_config.get('cql')
+
         log.debug('Starting gathering for %s' % url)
         guids_in_harvest = set()
         try:
-            for identifier in self.csw.getidentifiers(page=10, outputschema=self.output_schema()):
+            for identifier in self.csw.getidentifiers(page=10, outputschema=self.output_schema(), cql=cql):
                 try:
                     log.info('Got identifier %s from the CSW', identifier)
                     if identifier is None:

--- a/ckanext/spatial/lib/csw_client.py
+++ b/ckanext/spatial/lib/csw_client.py
@@ -95,7 +95,7 @@ class CswService(OwsService):
 
     def getidentifiers(self, qtype=None, typenames="csw:Record", esn="brief",
                        keywords=[], limit=None, page=10, outputschema="gmd",
-                       startposition=0, **kw):
+                       startposition=0, cql=None, **kw):
         from owslib.csw import namespaces
         constraints = []
         csw = self._ows(**kw)
@@ -110,6 +110,7 @@ class CswService(OwsService):
             "startposition": startposition,
             "maxrecords": page,
             "outputschema": namespaces[outputschema],
+            "cql":cql,
             }
         i = 0
         matches = 0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,6 +1,6 @@
 GeoAlchemy>=0.6
 Shapely>=1.2.13
-OWSLib==0.8.2
+OWSLib==0.8.6
 lxml>=2.3
 argparse
 pyparsing==1.5.6


### PR DESCRIPTION
Replaces #56: this branch should merge properly on master.

As per #55 (Allow CSW harvesters to define CQL filters):
- changes in py files to allow passing cql info
- changes in owslib version, to make the cql filtering work (some improvements were introduced in 0.8.4 and some more fixes in 0.8.6)
- fix `base.py` in resetting source config when no config is present for current harvest source 
