### PR TITLE
Minor clarification for template extension

### DIFF
--- a/doc/spatial-search.rst
+++ b/doc/spatial-search.rst
@@ -196,8 +196,10 @@ There are snippets already created to load the map on the left sidebar or in
 the main body of the dataset details page, but these can be easily modified to
 suit your project needs
 
-To add a map to the sidebar, add this to the dataset details page template (eg
-``ckanext-myproj/ckanext/myproj/templates/package/read.html``)::
+To add a map to the sidebar, add the following block to the dataset details page template (eg
+``ckanext-myproj/ckanext/myproj/templates/package/read.html``). If your custom 
+theme is simply extending the CKAN default theme, you will need to add ``{% ckan_extends %}`` 
+to the start of your custom read.html, then continue with this::
 
     {% block secondary_content %}
       {{ super() }}


### PR DESCRIPTION
When creating a minimal custom theme users may start with a blank read.html file and include only the secondary_content block. This will fail, as the template needs to start with ckan_extends.
