### PR TITLE
Patched Geoalchemy for PostGIS 2

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,4 +1,5 @@
-GeoAlchemy>=0.6
+# GeoAlchemy>=0.6
+-e git+https://github.com/chokoswitch/geoalchemy.git#egg=GeoAlchemy
 Shapely>=1.2.13
 OWSLib==0.8.6
 lxml>=2.3


### PR DESCRIPTION
To get CKAN 2.3 master (Dec 2014) to work with ckanext-spatial on a PostGIS 2.1.2 db (Ubuntu 14.04 FWIW), this patch uses a GelAlchemy version by @chokoswitch as I mentioned in #5 
@amercader is of course right to suggest upgrading CKAN's SQLAlchemy - in the mean time, here's a patch that works at least for me.