### PR TITLE
Resource preview for IResourceView in CKAN 2.3 (2nd try)

### DIFF
--- a/ckanext/spatial/nongeos_plugin.py
+++ b/ckanext/spatial/nongeos_plugin.py
@@ -2,60 +2,106 @@ import mimetypes
 from logging import getLogger
 
 from ckan import plugins as p
+import ckan.lib.datapreview as datapreview
 
 
 log = getLogger(__name__)
 
 
-class WMSPreview(p.SingletonPlugin):
-
+class DataViewBase(p.SingletonPlugin):
+    '''This base class is for view extensions. '''
+    if p.toolkit.check_ckan_version('2.3'):
+        p.implements(p.IResourceView, inherit=True)
+    else:
+        p.implements(p.IResourcePreview, inherit=True)
     p.implements(p.IConfigurer, inherit=True)
-    p.implements(p.IResourcePreview, inherit=True)
+    p.implements(p.IConfigurable, inherit=True)
 
-    WMS = ['wms']
+    proxy_is_enabled = False
+    same_domain = False
 
     def update_config(self, config):
-
         p.toolkit.add_public_directory(config, 'public')
         p.toolkit.add_template_directory(config, 'templates')
         p.toolkit.add_resource('public', 'ckanext-spatial')
 
-        self.proxy_enabled = p.toolkit.asbool(config.get('ckan.resource_proxy_enabled', 'False'))
+        config['ckan.resource_proxy_enabled'] = p.plugin_loaded('resource_proxy')
+
+    def configure(self, config):
+        enabled = config.get('ckan.resource_proxy_enabled', False)
+        self.proxy_is_enabled = enabled
 
     def setup_template_variables(self, context, data_dict):
         import ckanext.resourceproxy.plugin as proxy
-        if self.proxy_enabled and not data_dict['resource']['on_same_domain']:
-            p.toolkit.c.resource['proxy_url'] = proxy.get_proxified_resource_url(data_dict)
+        if p.toolkit.check_ckan_version('2.3'):
+            self.same_domain = datapreview.on_same_domain(data_dict)
         else:
-            p.toolkit.c.resource['proxy_url'] = data_dict['resource']['url']
+            self.same_domain = datapreview._on_same_domain(data_dict)
+        if self.proxy_is_enabled and not self.same_domain:
+            data_dict['resource']['original_url'] = data_dict['resource']['url']
+            data_dict['resource']['url'] = proxy.get_proxified_resource_url(data_dict)
 
-    def can_preview(self, data_dict):
-        format_lower = data_dict['resource']['format'].lower()
 
-        correct_format = format_lower in self.WMS
-        can_preview_from_domain = self.proxy_enabled or data_dict['resource']['on_same_domain']
-        quality = 2
+class WMSView(DataViewBase):
+    WMS = ['wms']
 
-        if p.toolkit.check_ckan_version('2.1'):
-            if correct_format:
-                if can_preview_from_domain:
-                    return {'can_preview': True, 'quality': quality}
+    if p.toolkit.check_ckan_version('2.3'):
+        def info(self):
+            return {'name': 'wms_view',
+                    'title': 'wms',
+                    'icon': 'map-marker',
+                    'iframed': True,
+                    'default_title': p.toolkit._('WMS'),
+                    }
+
+        def can_view(self, data_dict):
+            resource = data_dict['resource']
+            format_lower = resource['format'].lower()
+
+            if format_lower in self.WMS:
+                return self.same_domain or self.proxy_is_enabled
+            return False
+
+        def view_template(self, context, data_dict):
+            return 'dataviewer/wms.html'
+    else:
+        def can_preview(self, data_dict):
+            format_lower = data_dict['resource']['format'].lower()
+
+            correct_format = format_lower in self.WMS
+            can_preview_from_domain = self.proxy_is_enabled or data_dict['resource']['on_same_domain']
+            quality = 2
+
+            if p.toolkit.check_ckan_version('2.1'):
+                if correct_format:
+                    if can_preview_from_domain:
+                        return {'can_preview': True, 'quality': quality}
+                    else:
+                        return {'can_preview': False,
+                                'fixable': 'Enable resource_proxy',
+                                'quality': quality}
                 else:
-                    return {'can_preview': False,
-                            'fixable': 'Enable resource_proxy',
-                            'quality': quality}
-            else:
-                return {'can_preview': False, 'quality': quality}
+                    return {'can_preview': False, 'quality': quality}
 
-        return correct_format and can_preview_from_domain
+            return correct_format and can_preview_from_domain
 
-    def preview_template(self, context, data_dict):
-        return 'dataviewer/wms.html'
+        def preview_template(self, context, data_dict):
+            return 'dataviewer/wms.html'
+
+    def setup_template_variables(self, context, data_dict):
+        import ckanext.resourceproxy.plugin as proxy
+        if p.toolkit.check_ckan_version('2.3'):
+            self.same_domain = datapreview.on_same_domain(data_dict)
+        else:
+            self.same_domain = datapreview._on_same_domain(data_dict)
+        if self.proxy_is_enabled and not self.same_domain:
+            data_dict['resource']['proxy_url'] = proxy.get_proxified_resource_url(data_dict)
+
+        else:
+            data_dict['resource']['proxy_url'] = data_dict['resource']['url']
 
 
-class GeoJSONPreview(p.SingletonPlugin):
-    p.implements(p.IConfigurer, inherit=True)
-    p.implements(p.IResourcePreview, inherit=True)
+class GeoJSONView(DataViewBase):
     p.implements(p.ITemplateHelpers, inherit=True)
 
     GeoJSON = ['gjson', 'geojson']
@@ -65,45 +111,50 @@ class GeoJSONPreview(p.SingletonPlugin):
         template directory for the preview
         '''
 
-        p.toolkit.add_public_directory(config, 'public')
-        p.toolkit.add_template_directory(config, 'templates')
-        p.toolkit.add_resource('public', 'ckanext-spatial')
-
-        self.proxy_enabled = config.get(
-            'ckan.resource_proxy_enabled', False)
-
         mimetypes.add_type('application/json', '.geojson')
 
-    def can_preview(self, data_dict):
-        format_lower = data_dict['resource']['format'].lower()
+    if p.toolkit.check_ckan_version('2.3'):
+        def info(self):
+            return {'name': 'geojson_view',
+                    'title': 'GeoJSON',
+                    'icon': 'map-marker',
+                    'iframed': True,
+                    'default_title': p.toolkit._('GeoJSON'),
+                    }
 
-        correct_format = format_lower in self.GeoJSON
-        can_preview_from_domain = self.proxy_enabled or data_dict['resource']['on_same_domain']
-        quality = 2
+        def can_view(self, data_dict):
+            resource = data_dict['resource']
+            format_lower = resource['format'].lower()
 
-        if p.toolkit.check_ckan_version('2.1'):
-            if correct_format:
-                if can_preview_from_domain:
-                    return {'can_preview': True, 'quality': quality}
+            if format_lower in self.GeoJSON:
+                return self.same_domain or self.proxy_is_enabled
+            return False
+
+        def view_template(self, context, data_dict):
+            return 'dataviewer/geojson.html'
+    else:
+        def can_preview(self, data_dict):
+            format_lower = data_dict['resource']['format'].lower()
+
+            correct_format = format_lower in self.GeoJSON
+            can_preview_from_domain = self.proxy_is_enabled or data_dict['resource']['on_same_domain']
+            quality = 2
+
+            if p.toolkit.check_ckan_version('2.1'):
+                if correct_format:
+                    if can_preview_from_domain:
+                        return {'can_preview': True, 'quality': quality}
+                    else:
+                        return {'can_preview': False,
+                                'fixable': 'Enable resource_proxy',
+                                'quality': quality}
                 else:
-                    return {'can_preview': False,
-                            'fixable': 'Enable resource_proxy',
-                            'quality': quality}
-            else:
-                return {'can_preview': False, 'quality': quality}
+                    return {'can_preview': False, 'quality': quality}
 
-        return correct_format and can_preview_from_domain
+            return correct_format and can_preview_from_domain
 
-    def setup_template_variables(self, context, data_dict):
-        import ckanext.resourceproxy.plugin as proxy
-        if (self.proxy_enabled
-                and not data_dict['resource']['on_same_domain']):
-            p.toolkit.c.resource['original_url'] = p.toolkit.c.resource['url']
-            p.toolkit.c.resource['url'] = proxy.get_proxified_resource_url(
-                data_dict)
-
-    def preview_template(self, context, data_dict):
-        return 'dataviewer/geojson.html'
+        def preview_template(self, context, data_dict):
+            return 'dataviewer/geojson.html'
 
     ## ITemplateHelpers
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,10 @@ setup(
     [ckan.plugins]
     spatial_metadata=ckanext.spatial.plugin:SpatialMetadata
     spatial_query=ckanext.spatial.plugin:SpatialQuery
-    wms_preview=ckanext.spatial.nongeos_plugin:WMSPreview
-    geojson_preview=ckanext.spatial.nongeos_plugin:GeoJSONPreview
+    wms_view=ckanext.spatial.nongeos_plugin:WMSView
+    geojson_view=ckanext.spatial.nongeos_plugin:GeoJSONView
+    wms_preview=ckanext.spatial.nongeos_plugin:WMSView
+    geojson_preview=ckanext.spatial.nongeos_plugin:GeoJSONView
     cswserver=ckanext.spatial.plugin:CatalogueServiceWeb
     spatial_harvest_metadata_api=ckanext.spatial.plugin:HarvestMetadataApi
 


### PR DESCRIPTION
Just a naive implementation to make wms and geojson preview compatible for the new "IResourceView" interface, which introduced in CKAN 2.3. They are "wms_view" and "geojson_view".
The old "wms_preview" and "geojson_preview" are still available for CKAN version 2.2 or lower.