### PR TITLE
Fix delete in CSW. Closes #103.

### DIFF
--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -143,6 +143,14 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
         return ids
 
     def fetch_stage(self,harvest_object):
+
+        # Check harvest object status
+        status = self._get_object_extra(harvest_object, 'status')
+
+        if status == 'delete':
+            # No need to fetch anything, just pass to the import stage
+            return True
+
         log = logging.getLogger(__name__ + '.CSW.fetch')
         log.debug('CswHarvester fetch_stage for object: %s', harvest_object.id)
 


### PR DESCRIPTION
Records deleted on the remote CSW server are not deleted locally.
The ids of the records stored locally but no longer on the remote server are put in the fetch list, but the fetch stage will fail because the record is not found on the CSW server. The transaction object will be marked as failed, and the record as not current.

The fix just bypasses the fetch stage if the record has to be deleted.