### PR TITLE
[#112] bbox fix only kicks in with positive w-long and negative e-long

### DIFF
--- a/ckanext/spatial/public/js/dataset_map.js
+++ b/ckanext/spatial/public/js/dataset_map.js
@@ -26,12 +26,13 @@ this.ckan.module('dataset-map', function (jQuery, _) {
       this.extent = this.el.data('extent');
 
       // fix bbox when w-long is positive while e-long is negative.
+      // assuming coordinate sequence is west to east (left to right)
       if (this.extent.type == 'Polygon'
         && this.extent.coordinates[0].length == 5) {
         _coordinates = this.extent.coordinates[0]
         w = _coordinates[0][0];
         e = _coordinates[2][0];
-        if (w > e) {
+        if (w >= 0 && e < 0) {
           w_new = w
           while (w_new > e) w_new -=360
           for (var i = 0; i < _coordinates.length; i++) {


### PR DESCRIPTION
This limits previous fix to apply only when coordinates start with positive longitude and ends with negative longitude, which is the obvious scenario we want to fix. It wont affect coordinates that start from east(max-longitude) to west(min-longitude), or right to left, when both longitude are positives or negatives.