### PR TITLE
#114 solr-spatial-field search Solr 5 compatibility

### DIFF
--- a/ckanext/spatial/plugin.py
+++ b/ckanext/spatial/plugin.py
@@ -310,12 +310,12 @@ class SpatialQuery(p.SingletonPlugin):
         '''
         This will add an fq filter with the form:
 
-            +spatial_geom:"Intersects({minx} {miny} {maxx} {maxy})
+            +spatial_geom:"Intersects(ENVELOPE({minx}, {miny}, {maxx}, {maxy}))
 
         '''
         search_params['fq_list'] = search_params.get('fq_list', [])
-        search_params['fq_list'].append('+spatial_geom:"Intersects({minx} {miny} {maxx} {maxy})"'
-                                     .format(minx=bbox['minx'],miny=bbox['miny'],maxx=bbox['maxx'],maxy=bbox['maxy']))
+        search_params['fq_list'].append('+spatial_geom:"Intersects(ENVELOPE({minx}, {maxx}, {maxy}, {miny}))"'
+                                        .format(minx=bbox['minx'], miny=bbox['miny'], maxx=bbox['maxx'], maxy=bbox['maxy']))
 
         return search_params
 

--- a/doc/spatial-search.rst
+++ b/doc/spatial-search.rst
@@ -125,9 +125,10 @@ details about the available options:
             <!-- ... -->
             <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                 spatialContextFactory="com.spatial4j.core.context.jts.JtsSpatialContextFactory"
+                autoIndex="true"
                 distErrPct="0.025"
                 maxDistErr="0.000009"
-                units="degrees" />
+                distanceUnits="degrees" />
         </types>
         <fields>
             <!-- ... -->


### PR DESCRIPTION
Updates solr-spatial-field query method for Solr 5 compatibility. Tested on Solr 5.3.0. Based on https://gist.github.com/u10313335/5649488bc3a4037e1357 which resolves #114 according to comments in that issue.