### PR TITLE
pinned requests to version 2.7.0

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -5,4 +5,4 @@ OWSLib==0.8.6
 lxml>=2.3
 argparse
 pyparsing==1.5.6
-requests==1.1.0
+requests==2.7.0


### PR DESCRIPTION
Using requests version 1.1.0 is problematic with Debian 8 or other systems where SSLv3 support has been disabled. For that and other reasons core ckan now requires requests==2.7.0, which apparently has been tested with ckanext-spatial (see https://github.com/ckan/ckan/issues/2470). To avoid accidental downgrading when installing ckanext-spatial, I suggest to also pin requests to 2.7.0.