### PR TITLE
[#2470] Allow newer requests versions. 

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -387,7 +387,7 @@ Configure with the SO directory you found before::
 Now make it and install it::
 
     $ make
-  $ sudo make install
+    $ sudo make install
 
 Now check the install by running xmllint::
 

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -5,4 +5,4 @@ OWSLib==0.8.6
 lxml>=2.3
 argparse
 pyparsing==1.5.6
-requests==1.1.0
+requests>=1.1.0


### PR DESCRIPTION
Tested with 2.7. Its only the WAF harvester that currently uses it, and that is only basic use.