### PR TITLE
fix map attribution

### DIFF
--- a/ckanext/spatial/templates/spatial/snippets/map_attribution.html
+++ b/ckanext/spatial/templates/spatial/snippets/map_attribution.html
@@ -1,10 +1,11 @@
-<div>Map data &copy; <a
-href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors</div>
-{% if map_config.type == 'mapbox' %}
-  <div>Tiles by <a href="http://www.mapbox.com/about/maps/">MapBox</a></div>
-{% elif map_config.type == 'custom' %}
+{% if map_config.type == 'custom' %}
   <div>{{ map_config.attribution|safe }}</div>
 {% else %}
-  <div>Tiles by <a href="http://www.mapquest.com">MapQuest</a></div>
+  <div>Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors</div>
+  {% if map_config.type == 'mapbox' %}
+    <div>Tiles by <a href="http://www.mapbox.com/about/maps/">MapBox</a></div>
+  {% else %}
+    <div>Tiles by <a href="http://www.mapquest.com">MapQuest</a></div>
+  {% endif %}
 {% endif %}
 


### PR DESCRIPTION
If ckanext.spatial.common_map.type = custom then the map data is not necessarily &copy; OpenStreetMap (e.g. I am using swisstopo's maps and WMTS). But this was rendered nonetheless. Now, in that case, only the attribution set by ckanext.spatial.common_map.attribution is shown. Otherwise behaviour doesn't change. Hope that makes sense. 