### PR TITLE
Set tms option for custom layer

### DIFF
--- a/ckanext/spatial/public/js/common_map.js
+++ b/ckanext/spatial/public/js/common_map.js
@@ -52,6 +52,7 @@
           // Custom XYZ layer
           baseLayerUrl = mapConfig['custom.url'];
           if (mapConfig.subdomains) leafletBaseLayerOptions.subdomains = mapConfig.subdomains;
+          if (mapConfig.tms) leafletBaseLayerOptions.tms = mapConfig.tms;
           leafletBaseLayerOptions.attribution = mapConfig.attribution;
       } else {
           // MapQuest OpenStreetMap base map


### PR DESCRIPTION
Set the L.TileLayer as a TMS. It's required if the base layer specified in custom.url is a TMS. The default value of tms is false in Leaflet.
To use the TMS option, ```ckanext.spatial.common_map.tms = true``` has to be set in the ckan .INI file.

Same as https://github.com/ckan/ckanext-geoview/pull/24