### PR TITLE
force all CSW GetRecords requests to set ogc:SortBy to ensure proper ordering

### DIFF
--- a/ckanext/spatial/lib/csw_client.py
+++ b/ckanext/spatial/lib/csw_client.py
@@ -68,6 +68,7 @@ class CswService(OwsService):
     from owslib.csw import CatalogueServiceWeb as _Implementation
 
     def __init__(self):
+        super(CswService, self).__init__()
         self.sortby = SortBy([SortProperty('dc:identifier')])
 
     def getrecords(self, qtype=None, keywords=[],

--- a/ckanext/spatial/lib/csw_client.py
+++ b/ckanext/spatial/lib/csw_client.py
@@ -6,7 +6,7 @@ for convenience.
 import logging
 
 from owslib.etree import etree
-from owslib.fes import PropertyIsEqualTo
+from owslib.fes import PropertyIsEqualTo, SortBy, SortProperty
 
 log = logging.getLogger(__name__)
 
@@ -66,6 +66,10 @@ class CswService(OwsService):
     Perform various operations on a CSW service
     """
     from owslib.csw import CatalogueServiceWeb as _Implementation
+
+    def __init__(self):
+        self.sortby = SortBy([SortProperty('dc:identifier')])
+
     def getrecords(self, qtype=None, keywords=[],
                    typenames="csw:Record", esn="brief",
                    skip=0, count=10, outputschema="gmd", **kw):
@@ -83,6 +87,7 @@ class CswService(OwsService):
             "startposition": skip,
             "maxrecords": count,
             "outputschema": namespaces[outputschema],
+            "sortby": self.sortby
             }
         log.info('Making CSW request: getrecords2 %r', kwa)
         csw.getrecords2(**kwa)
@@ -110,7 +115,8 @@ class CswService(OwsService):
             "startposition": startposition,
             "maxrecords": page,
             "outputschema": namespaces[outputschema],
-            "cql":cql,
+            "cql": cql,
+            "sortby": self.sortby
             }
         i = 0
         matches = 0


### PR DESCRIPTION
cc @FuhuXia

## Overview

As per https://github.com/geopython/pycsw/issues/301, this PR forces CKAN's CSW client to explicitly set sorting so that a given CSW server can return results in a consistent manner.