### PR TITLE
Metadata license ID check for package

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -290,13 +290,14 @@ class SpatialHarvester(HarvesterBase):
         use_constraints = iso_values.get('use-constraints')
         if use_constraints:
 
-            license_list = logic.action.get.license_list({'model': model, 'session': model.Session, 'user': 'harvest'}, {})
+            context = {'model': model, 'session': model.Session, 'user': self._get_user_name()}
+            license_list = p.toolkit.get_action('license_list')(context, {})
 
             for constraint in use_constraints:
                 package_license = None
 
                 for license in license_list:
-                    if constraint == str(license.get('id')) or constraint == str(license.get('url')) or (str(license.get('id')) in constraint.lower()):
+                    if constraint.lower() == license.get('id') or constraint == license.get('url'):
                         package_license = license.get('id')
                         break
 

--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -285,6 +285,26 @@ class SpatialHarvester(HarvesterBase):
             if license_url_extracted:
                 extras['licence_url'] = license_url_extracted
 
+
+        # Metadata license ID check for package
+        use_constraints = iso_values.get('use-constraints')
+        if use_constraints:
+
+            license_list = logic.action.get.license_list({'model': model, 'session': model.Session, 'user': 'harvest'}, {})
+
+            for constraint in use_constraints:
+                package_license = None
+
+                for license in license_list:
+                    if constraint == str(license.get('id')) or constraint == str(license.get('url')) or (str(license.get('id')) in constraint.lower()):
+                        package_license = license.get('id')
+                        break
+
+                if package_license:
+                    package_dict['license_id'] = package_license
+                    break
+
+
         extras['access_constraints'] = iso_values.get('limitations-on-public-access', '')
 
         # Grpahic preview


### PR DESCRIPTION
Dear All,

the purpose of this pull request is to provide the possibility to assign the license id
to a package from the gmd:useLimitation metadata element.
In some cases I needed to do that in the CSW harvesting because the current code set 
only the extras fields but not the package 'license_id' (this means no license link available 
from the left side menu and avoid the possibility to search dataset by license).
As I know a metadata could contain multiple occurrences of the gmd:uselLimitation element,
so my code assigns to the package the first license that match in the available licenses list of Ckan.
