### PR TITLE
Fix missing import in before_index

### DIFF
--- a/ckanext/spatial/plugin.py
+++ b/ckanext/spatial/plugin.py
@@ -175,6 +175,7 @@ class SpatialQuery(p.SingletonPlugin):
 
     def before_index(self, pkg_dict):
         import shapely
+        import shapely.geometry
 
         if pkg_dict.get('extras_spatial', None) and self.search_backend in ('solr', 'solr-spatial-field'):
             try:


### PR DESCRIPTION
[Most] versions of shapely do not have `geometry` imported at the top level. Import it explicitly to prevent indexing errors instead of relying on import side-effects.