### PR TITLE
Feature/allow csw constraints

### DIFF
--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -62,6 +62,9 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
     def output_schema(self):
         return 'gmd'
 
+    def get_constraints(self):
+        return []
+
     def gather_stage(self, harvest_job):
         log = logging.getLogger(__name__ + '.CSW.gather')
         log.debug('CswHarvester gather_stage for job: %r', harvest_job)
@@ -92,7 +95,7 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
         log.debug('Starting gathering for %s' % url)
         guids_in_harvest = set()
         try:
-            for identifier in self.csw.getidentifiers(page=10, outputschema=self.output_schema(), cql=cql):
+            for identifier in self.csw.getidentifiers(page=10, outputschema=self.output_schema(), cql=cql, constraints=self.get_constraints()):
                 try:
                     log.info('Got identifier %s from the CSW', identifier)
                     if identifier is None:

--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -63,6 +63,9 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
         return 'gmd'
 
     def get_constraints(self):
+        '''Returns the CSW constraints that should be used during gather stage.
+        Should be overwritten by sub-classes.
+        '''
         return []
 
     def gather_stage(self, harvest_job):

--- a/ckanext/spatial/lib/csw_client.py
+++ b/ckanext/spatial/lib/csw_client.py
@@ -101,9 +101,8 @@ class CswService(OwsService):
 
     def getidentifiers(self, qtype=None, typenames="csw:Record", esn="brief",
                        keywords=[], limit=None, page=10, outputschema="gmd",
-                       startposition=0, cql=None, **kw):
+                       startposition=0, cql=None, constraints=[], **kw):
         from owslib.csw import namespaces
-        constraints = []
         csw = self._ows(**kw)
 
         if qtype is not None:


### PR DESCRIPTION
* extends `ckanext.spatial.lib.CswService.getidentifiers()` with `constraints` parameter, which will simply be passed on as the `constraints` parameter to owslib's `get_records2()`
* extends `ckanext.spatial.harvesters.CSWHarvester` with new `get_constraints()` function
** `CSWHarvester` simply returns an empty list (i.e., no constraint), but sub-classes can overwrite this
** `get_constraints()` is being called from `gather_stage()`
* **Note:** the current setup means that constraints can only be set if a sub-class of `CSWHarvester` is being used. This is exactly what I need. If constraints need to be used from plain `CSWHarvester`, additional code would be need to allow entering the constraints as part of the harvester's config.