### PR TITLE
[#191] skip dataset during import

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -566,6 +566,10 @@ class SpatialHarvester(HarvesterBase):
             log.error('No package dict returned, aborting import for object {0}'.format(harvest_object.id))
             return False
 
+        if package_dict == 'skip':
+            log.info('Skipping import for object {0}'.format(harvest_object.id))
+            return 'unchanged'
+
         # Create / update the package
         context.update({
            'extras_as_string': True,

--- a/doc/harvesters.rst
+++ b/doc/harvesters.rst
@@ -95,6 +95,24 @@ allows to tweak the dataset fields before creating or updating it::
 
             return package_dict
 
+It is possible to return ``'skip'`` if you want to prevent a dataset from being imported. This is useful if only datasets that fulfil certain criteria should be imported. In the following example, only datasets tagged ``opendata`` will be imported::
+
+    def get_package_dict(self, context, data_dict):
+
+        package_dict = data_dict['package_dict']
+        iso_values = data_dict['iso_values']
+
+        # checking for 'opendata' tag
+        tags = iso_values['tags']
+        if not 'opendata' in tags:
+            return 'skip'
+
+        # continue with custom code ...
+
+        return package_dict
+
+
+
 ``get_validators`` allows to register custom validation classes that can be
 applied to the harvested documents. Check the `Writing custom validators`_
 section to know more about how to write your custom validators::

--- a/doc/harvesters.rst
+++ b/doc/harvesters.rst
@@ -95,7 +95,7 @@ allows to tweak the dataset fields before creating or updating it::
 
             return package_dict
 
-It is possible to return ``'skip'`` if you want to prevent a dataset from being imported. This is useful if only datasets that fulfil certain criteria should be imported. In the following example, only datasets tagged ``opendata`` will be imported::
+It is possible to return ``'skip'`` if you want to prevent a dataset from being imported, but not have it register as an error or failed import (returning ``False`` will have that effect). This is useful if only datasets that fulfil certain criteria should be imported. In the following example, only datasets tagged ``opendata`` will be imported::
 
     def get_package_dict(self, context, data_dict):
 


### PR DESCRIPTION
* Allows `get_package_dict()` to return `'skip'` in cases where a dataset should, upon closer inspection, not be imported after all.
* `'skip'` will be caught in `import_stage()`, which then returns `'unchanged'`, following the documentation at https://github.com/ckan/ckanext-harvest#the-harvesting-interface.
* **Note:** This setup assumes an alternative implementation of `get_package_dict()`, e.g. in a sub-class of `SpatialHarvester`.