### PR TITLE
Remove ckanext.spatial from namespace_packages in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
 	url='http://okfn.org',
 	license='AGPL',
 	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext', 'ckanext.spatial'],
+	namespace_packages=['ckanext'],
 	include_package_data=True,
 	zip_safe=False,
 	install_requires=[


### PR DESCRIPTION
When trying to pip install a checkout of ckanext-spatial, any further attempt to interact with the virtualenv (python or pip) breaks with a KeyError: 'ckanext'.  

This appears to be documented at:  https://github.com/ckan/ckanext-pdfview/issues/17 and https://github.com/ckan/ckanext-geoview/issues/39

