### PR TITLE
The expected key may not be set - this stops a KeyError

### DIFF
--- a/ckanext/spatial/tests/test_harvest.py
+++ b/ckanext/spatial/tests/test_harvest.py
@@ -265,6 +265,8 @@ class TestHarvest(HarvestFixtureBase):
 
         resource = package_dict['resources'][0]
         for key,value in expected_resource.iteritems():
+            if not key in resource:
+                raise AssertionError('Expected key not in resource: %s' % (key))
             if not resource[key] == value:
                 raise AssertionError('Unexpected value in resource for %s: %s (was expecting %s)' % \
                     (key, resource[key], value))


### PR DESCRIPTION
There may be cases where the key is not present (this is particularly true of `verified` which is unset by default).  This is currently raising a KeyError, rather than an AssertionError.