### PR TITLE
[harvest] fixes https://github.com/ckan/ckanext-spatial/issues/225

### DIFF
--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -180,6 +180,7 @@ class ISOResourceLocator(ISOElement):
             name="name",
             search_paths=[
                 "gmd:name/gco:CharacterString/text()",
+                "gmd:name/gmx:MimeFileType/text()",
             ],
             multiplicity="0..1",
         ),


### PR DESCRIPTION
Should support gmx:MimeFileType instead of gco:CharacterString in the resources' gmd:Name tag
```
<gmd:name>
  <gmx:MimeFileType type="application/octet-stream">
     Fichier KMZ à télécharger
  </gmx:MimeFileType>
</gmd:name>
```