### PR TITLE
[leaflet] add support for zoomOffset option for TMS source

### DIFF
--- a/ckanext/spatial/public/js/common_map.js
+++ b/ckanext/spatial/public/js/common_map.js
@@ -58,6 +58,7 @@
           baseLayerUrl = mapConfig['custom.url'];
           if (mapConfig.subdomains) leafletBaseLayerOptions.subdomains = mapConfig.subdomains;
           if (mapConfig.tms) leafletBaseLayerOptions.tms = mapConfig.tms;
+          if (mapConfig.zoomOffset) leafletBaseLayerOptions.zoomOffset = parseInt(mapConfig.zoomOffset);
           leafletBaseLayerOptions.attribution = mapConfig.attribution;
 
           baseLayer = new L.TileLayer(baseLayerUrl, leafletBaseLayerOptions);


### PR DESCRIPTION
For many TMS sources, the zoomOffset option is important (prevents you from using a source)
