### PR TITLE
Fix shapely deprecation warning

### DIFF
--- a/ckanext/spatial/lib/__init__.py
+++ b/ckanext/spatial/lib/__init__.py
@@ -6,7 +6,7 @@ from ckan.model import Session, Package
 import ckantoolkit as tk
 
 from ckanext.spatial.model import PackageExtent
-from shapely.geometry import asShape
+from shapely.geometry import shape
 
 
 from ckanext.spatial.geoalchemy_common import (WKTElement, ST_Transform,
@@ -53,13 +53,13 @@ def save_package_extent(package_id, geometry = None, srid = None):
     existing_package_extent = Session.query(PackageExtent).filter(PackageExtent.package_id==package_id).first()
 
     if geometry:
-        shape = asShape(geometry)
+        geom_obj = shape(geometry)
 
         if not srid:
             srid = db_srid
 
         package_extent = PackageExtent(package_id=package_id,
-                                       the_geom=WKTElement(shape.wkt, srid))
+                                       the_geom=WKTElement(geom_obj.wkt, srid))
 
     # Check if extent exists
     if existing_package_extent:

--- a/ckanext/spatial/plugin/__init__.py
+++ b/ckanext/spatial/plugin/__init__.py
@@ -223,13 +223,12 @@ class SpatialQuery(SpatialQueryMixin, p.SingletonPlugin):
                         # Check if coordinates are defined counter-clockwise,
                         # otherwise we'll get wrong results from Solr
                         lr = shapely.geometry.polygon.LinearRing(geometry['coordinates'][0])
-                        if not lr.is_ccw:
-                            lr.coords = list(lr.coords)[::-1]
-                        polygon = shapely.geometry.polygon.Polygon(lr)
+                        lr_coords = list(lr.coords) if lr.is_ccw else reversed(list(lr.coords))
+                        polygon = shapely.geometry.polygon.Polygon(lr_coords)
                         wkt = polygon.wkt
 
                 if not wkt:
-                    shape = shapely.geometry.asShape(geometry)
+                    shape = shapely.geometry.shape(geometry)
                     if not shape.is_valid:
                         log.error('Wrong geometry, not indexing')
                         return pkg_dict

--- a/ckanext/spatial/tests/lib/test_spatial.py
+++ b/ckanext/spatial/tests/lib/test_spatial.py
@@ -5,7 +5,7 @@ import random
 
 import pytest
 
-from shapely.geometry import asShape
+from shapely.geometry import shape
 
 from ckan import model
 from ckan import plugins
@@ -43,9 +43,9 @@ class TestCompareGeometries(SpatialTestBase):
     def _get_extent_object(self, geometry):
         if isinstance(geometry, six.string_types):
             geometry = json.loads(geometry)
-        shape = asShape(geometry)
+        geom_obj = shape(geometry)
         return PackageExtent(
-            package_id="xxx", the_geom=WKTElement(shape.wkt, 4326)
+            package_id="xxx", the_geom=WKTElement(geom_obj.wkt, 4326)
         )
 
     def test_same_points(self):

--- a/ckanext/spatial/tests/model/test_package_extent.py
+++ b/ckanext/spatial/tests/model/test_package_extent.py
@@ -1,11 +1,10 @@
 import pytest
 
-from shapely.geometry import asShape
+from shapely.geometry import shape
 
 from ckan.model import Session
 from ckan.lib.helpers import json
 
-import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
 
 from ckanext.spatial.model import PackageExtent
@@ -21,10 +20,10 @@ class TestPackageExtent(SpatialTestBase):
 
         geojson = json.loads(self.geojson_examples["point"])
 
-        shape = asShape(geojson)
+        geom_obj = shape(geojson)
         package_extent = PackageExtent(
             package_id=package["id"],
-            the_geom=WKTElement(shape.wkt, self.db_srid),
+            the_geom=WKTElement(geom_obj.wkt, self.db_srid),
         )
         package_extent.save()
 
@@ -60,10 +59,10 @@ class TestPackageExtent(SpatialTestBase):
 
         geojson = json.loads(self.geojson_examples["point"])
 
-        shape = asShape(geojson)
+        geom_obj = shape(geojson)
         package_extent = PackageExtent(
             package_id=package["id"],
-            the_geom=WKTElement(shape.wkt, self.db_srid),
+            the_geom=WKTElement(geom_obj.wkt, self.db_srid),
         )
         package_extent.save()
         if legacy_geoalchemy:
@@ -84,8 +83,8 @@ class TestPackageExtent(SpatialTestBase):
         # Update the geometry (Point -> Polygon)
         geojson = json.loads(self.geojson_examples["polygon"])
 
-        shape = asShape(geojson)
-        package_extent.the_geom = WKTElement(shape.wkt, self.db_srid)
+        geom_obj = shape(geojson)
+        package_extent.the_geom = WKTElement(geom_obj.wkt, self.db_srid)
         package_extent.save()
 
         assert(package_extent.package_id == package["id"])


### PR DESCRIPTION
There are some shapely deprecations that related to ckanext-spatial:
1. `asShape` is deprecated in favor of `shape`
2. geom objects are immutable now