### PR TITLE
Fix HTML view of ISO XML

### DIFF
--- a/ckanext/spatial/tests/test_api.py
+++ b/ckanext/spatial/tests/test_api.py
@@ -216,6 +216,13 @@ class TestHarvestedMetadataAPI(SpatialTestBase):
             '<?xml version="1.0" encoding="UTF-8"?>\n<xml>Content 1</xml>'
         )
 
+        # Access human-readable view of content
+        url = "/harvest/object/{0}/html".format(object_id_1)
+        r = app.get(url, status=200)
+        assert(
+            r.headers["Content-Type"] == "text/html; charset=utf-8"
+        )
+
         # Access original content in object extra (if present)
         url = "/harvest/object/{0}/original".format(object_id_1)
         r = app.get(url, status=404)

--- a/ckanext/spatial/util.py
+++ b/ckanext/spatial/util.py
@@ -186,11 +186,11 @@ def get_harvest_object_content(id):
         return None
 
 
-def _transform_to_html(content, xslt_package=None, xslt_path=None):
+def transform_to_html(content, xslt_package=None, xslt_path=None):
 
     xslt_package = xslt_package or __name__
     xslt_path = xslt_path or \
-        '../templates/ckanext/spatial/gemini2-html-stylesheet.xsl'
+        'templates/ckanext/spatial/gemini2-html-stylesheet.xsl'
 
     # optimise -- read transform only once and compile rather
     # than at each request


### PR DESCRIPTION

These changes seem necessary to resolve the link `/harvest/object/<id>/html` under CKAN 2.9 and python 3.

