### PR TITLE
Add nginx WAF server

### DIFF
--- a/ckanext/spatial/harvesters/waf.py
+++ b/ckanext/spatial/harvesters/waf.py
@@ -235,6 +235,16 @@ apache  = parse.SkipTo(parse.CaselessLiteral("<a href="), include=True).suppress
         ,adjacent=False, joinString=' ').setResultsName('date')
         )
 
+nginx   = parse.SkipTo(parse.CaselessLiteral("<a href="), include=True).suppress() \
+        + parse.quotedString.setParseAction(parse.removeQuotes).setResultsName('url') \
+        + parse.SkipTo("</a>", include=True).suppress() \
+        + parse.Optional(parse.Literal('</td><td align="right">')).suppress() \
+        + parse.Optional(parse.Combine(
+            parse.Word(parse.alphanums+'-') +
+            parse.Word(parse.alphanums+':')
+        ,adjacent=False, joinString=' ').setResultsName('date')
+        )
+
 iis =      parse.SkipTo("<br>").suppress() \
          + parse.OneOrMore("<br>").suppress() \
          + parse.Optional(parse.Combine(
@@ -252,12 +262,15 @@ other = parse.SkipTo(parse.CaselessLiteral("<a href="), include=True).suppress()
 
 
 scrapers = {'apache': parse.OneOrMore(parse.Group(apache)),
+            'nginx': parse.OneOrMore(parse.Group(nginx)),
             'other': parse.OneOrMore(parse.Group(other)),
             'iis': parse.OneOrMore(parse.Group(iis))}
 
 def _get_scraper(server):
     if not server or 'apache' in server.lower():
         return 'apache'
+    if 'nginx' in server.lower():
+        return 'nginx'
     if server == 'Microsoft-IIS/7.5':
         return 'iis'
     else:

--- a/ckanext/spatial/tests/test_api.py
+++ b/ckanext/spatial/tests/test_api.py
@@ -216,6 +216,13 @@ class TestHarvestedMetadataAPI(SpatialTestBase):
             '<?xml version="1.0" encoding="UTF-8"?>\n<xml>Content 1</xml>'
         )
 
+        # Access human-readable view of content
+        url = "/harvest/object/{0}/html".format(object_id_1)
+        r = app.get(url, status=200)
+        assert(
+            r.headers["Content-Type"] == "text/html; charset=utf-8"
+        )
+
         # Access original content in object extra (if present)
         url = "/harvest/object/{0}/original".format(object_id_1)
         r = app.get(url, status=404)

--- a/ckanext/spatial/util.py
+++ b/ckanext/spatial/util.py
@@ -186,11 +186,11 @@ def get_harvest_object_content(id):
         return None
 
 
-def _transform_to_html(content, xslt_package=None, xslt_path=None):
+def transform_to_html(content, xslt_package=None, xslt_path=None):
 
     xslt_package = xslt_package or __name__
     xslt_path = xslt_path or \
-        '../templates/ckanext/spatial/gemini2-html-stylesheet.xsl'
+        'templates/ckanext/spatial/gemini2-html-stylesheet.xsl'
 
     # optimise -- read transform only once and compile rather
     # than at each request


### PR DESCRIPTION

If the WAF contents are served by nginx instead of apache, this change allows the last-modified dates for XML records to be parsed and included in the harvest database.

Without this change, all XML records are assumed to be new, because there is no last-modified date in the database.   This can result in a great deal of extra harvesting operations in WAFs that have hundreds or thousands of XML records.