### PR TITLE
Allow objects with cleared job ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ syntax: glob
 *~
 dist
 build
+.vscode/
+.idea/

--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -683,9 +683,11 @@ class SpatialHarvester(HarvesterBase):
             # Check if the modified date is more recent
             if not self.force_import and previous_object and harvest_object.metadata_modified_date <= previous_object.metadata_modified_date:
 
-                # Assign the previous job id to the new object to
-                # avoid losing history
-                harvest_object.harvest_job_id = previous_object.job.id
+                # Assign the previous job id (if it hasn't been cleared) to the new object to avoid losing history
+                if previous_object.job:
+                    harvest_object.harvest_job_id = previous_object.job.id
+                else:
+                    harvest_object.harvest_job_id = None
                 harvest_object.add()
 
                 # Delete the previous object to avoid cluttering the object table


### PR DESCRIPTION

Handle the case where a harvest job id has been cleared.

Used in conjunction with this PR:  ckan/ckanext-spatial#505