### PR TITLE
Remove coupled resources from solr

### DIFF
--- a/ckanext/spatial/plugin/__init__.py
+++ b/ckanext/spatial/plugin/__init__.py
@@ -249,6 +249,10 @@ class SpatialQuery(SpatialQueryMixin, p.SingletonPlugin):
 
                 pkg_dict['spatial_geom'] = wkt
 
+        # Coupled resources are URL -> uuid links, they are not needed in SOLR
+        # and might be huge if there are lot of coupled resources
+        if pkg_dict.get('coupled-resource'):
+            pkg_dict.pop('coupled-resource')
 
         return pkg_dict
 


### PR DESCRIPTION
Coupled resources are a list of resources which link CSW server url and UUID together. These are not needed in SOLR as they hardly are searchable and might result in solr indexing error if single harvested dataset has many of them in it. This is based on discussion on https://github.com/ckan/ckan/pull/4825 