### PR TITLE
Pin shapely

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,7 +1,7 @@
 ckantoolkit
 GeoAlchemy>=0.6
 GeoAlchemy2==0.5.0
-Shapely>=1.2.13
+Shapely>=1.2.13,<2.0.0
 pyproj==2.2.2
 OWSLib==0.18.0
 lxml>=2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ckantoolkit
 GeoAlchemy>=0.6
 GeoAlchemy2==0.5.0
-Shapely>=1.2.13
+Shapely>=1.2.13,<2.0.0
 pyproj==2.6.1
 OWSLib==0.18.0
 lxml>=2.3


### PR DESCRIPTION
Shapely 2.0.0 removed deprecated asShape, which causes errors if it installed. Python 3.6 was removed from github actions, so this upgrades that as well