### PR TITLE
TypeError when spatial is missing

### DIFF
--- a/ckanext/spatial/search/__init__.py
+++ b/ckanext/spatial/search/__init__.py
@@ -19,6 +19,9 @@ class SpatialSearchBackend:
     """Base class for all datastore backends."""
 
     def parse_geojson(self, geom_from_metadata):
+        if not geom_from_metadata:
+            log.error("Metadata does not contain geometry, not indexing")
+            return None
 
         try:
             geometry = json.loads(geom_from_metadata)

--- a/ckanext/spatial/search/__init__.py
+++ b/ckanext/spatial/search/__init__.py
@@ -19,10 +19,6 @@ class SpatialSearchBackend:
     """Base class for all datastore backends."""
 
     def parse_geojson(self, geom_from_metadata):
-        if not geom_from_metadata:
-            log.error("Metadata does not contain geometry, not indexing")
-            return None
-
         try:
             geometry = json.loads(geom_from_metadata)
         except (AttributeError, ValueError) as e:
@@ -53,6 +49,9 @@ class SolrBBoxSearchBackend(SpatialSearchBackend):
         """
 
         geom_from_metadata = dataset_dict.get("spatial")
+        if not geom_from_metadata:
+            return dataset_dict
+
         geometry = self.parse_geojson(geom_from_metadata)
         shape = self.shape_from_geometry(geometry)
 
@@ -133,6 +132,9 @@ class SolrSpatialFieldSearchBackend(SpatialSearchBackend):
     def index_dataset(self, dataset_dict):
         wkt = None
         geom_from_metadata = dataset_dict.get("spatial")
+        if not geom_from_metadata:
+            return dataset_dict
+
         geometry = self.parse_geojson(geom_from_metadata)
         if not geometry:
             return dataset_dict

--- a/ckanext/spatial/search/__init__.py
+++ b/ckanext/spatial/search/__init__.py
@@ -19,6 +19,7 @@ class SpatialSearchBackend:
     """Base class for all datastore backends."""
 
     def parse_geojson(self, geom_from_metadata):
+
         try:
             geometry = json.loads(geom_from_metadata)
         except (AttributeError, ValueError) as e:


### PR DESCRIPTION
Problem:
There is an assumption in the code [that geometry may be missing from the metadata](https://github.com/ckan/ckanext-spatial/blob/master/ckanext/spatial/search/__init__.py#L52-L53)

But code [doesn't handle TypeError](https://github.com/ckan/ckanext-spatial/blob/master/ckanext/spatial/search/__init__.py#L25) which is raised in this case. 


Solution:
Skip an attempt to parse missing geometry as a JSON value + explicitly notify user about missing geometry.
