### PR TITLE
Upgrade tests to check all envs, including CKAN 2.10 with Python 3.10

### DIFF
--- a/.github/workflows/test-postgis.yml
+++ b/.github/workflows/test-postgis.yml
@@ -17,7 +17,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: [2.9, 2.9-py2]
       fail-fast: false
     
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   lint:
@@ -20,13 +20,19 @@ jobs:
         include:
           - ckan-version: "2.10"
             solr-image: "2.10-spatial"
+            harvest-tag: 'v1.4.2'
+            requirements-file: 'requirements.txt'
           - ckan-version: 2.9
             solr-image: 2.9-solr8-spatial
+            harvest-tag: 'v1.4.2'
+            requirements-file: 'requirements.txt'
           - ckan-version: 2.9-py2
             solr-image: 2.9-py2-solr8-spatial
+            harvest-tag: 'v1.4.0'
+            requirements-file: 'requirements-py2.txt'
       fail-fast: false
     
-    name: CKAN ${{ matrix.ckan-version }}
+    name: CKAN ${{ matrix.ckan-version }}, Solr ${{ matrix.solr-image }}
     runs-on: ubuntu-latest
     container:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
@@ -52,13 +58,7 @@ jobs:
     
     steps:
     - uses: actions/checkout@v3
-    - name: Install harvester
-      run: |
-        git clone https://github.com/ckan/ckanext-harvest
-        cd ckanext-harvest
-        pip install -r pip-requirements.txt
-        pip install -r dev-requirements.txt
-        pip install -e .
+  
     - name: Install dependencies (common)
       run: |
         apk add --no-cache \
@@ -71,18 +71,25 @@ jobs:
           gcc \
           libxml2-dev \
           libxslt-dev
-    - name: Install dependencies (python2)
-      if: ${{ matrix.ckan-version == '2.9-py2' || matrix.ckan-version == '2.8' || matrix.ckan-version == '2.7' }}
+
+    - name: Install dependencies from ${{ matrix.requirements-file }}
       run: |
-        apk add --no-cache \
-          python2-dev
-        pip install -r requirements-py2.txt
-    - name: Install dependencies (python3)
-      if: ${{ matrix.ckan-version != '2.9-py2' && matrix.ckan-version != '2.8' && matrix.ckan-version != '2.7' }}
+        pip install -r ${{ matrix.requirements-file }}
+
+    - name: Install harvester
       run: |
-        apk add --no-cache \
-          python3-dev
-        pip install -r requirements.txt
+        echo "Installing harvester from tag ${{ matrix.harvest-tag }}"
+        git clone --depth 1 --branch ${{ matrix.harvest-tag }} https://github.com/ckan/ckanext-harvest
+        cd ckanext-harvest
+        echo "upgrade pip"
+        pip install --upgrade pip
+        echo "Installing harvester requirements"
+        pip install -r pip-requirements.txt
+        echo "Installing harvester dev-requirements"
+        pip install -r dev-requirements.txt
+        echo "Installing harvester extension"
+        pip install -e .
+
     - name: Install requirements
       run: |
         pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,11 +69,31 @@ jobs:
           libxml2-dev \
           libxslt-dev
 
+    - name: Enable pip cache
+      run: |
+        echo "PIP version: $(pip --version)"
+        mkdir -p ~/.cache/pip
+        pip install -U pip --cache-dir ~/.cache/pip
+        chown -R $(whoami) ~/.cache/pip
+
+    - uses: actions/cache@v3
+      id: cache
+      with:
+        path: |
+          ~/.cache/pip
+          .
+          /usr/lib/python*/site-packages
+        key: ${{ runner.os }}-spatial-ckan-${{ matrix.ckan-version }}-${{ hashFiles('*requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-spatial-ckan-${{ matrix.ckan-version }}-${{ hashFiles('*requirements*.txt') }}
+
     - name: Install dependencies from ${{ matrix.requirements-file }}
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         pip install -r ${{ matrix.requirements-file }}
 
     - name: Install harvester
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         echo "Installing harvester"
         git clone --depth 1 https://github.com/ckan/ckanext-harvest
@@ -88,10 +108,14 @@ jobs:
         pip install -e .
 
     - name: Install requirements
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: pip install -e .
+
+    - name: Replace default path to CKAN
       run: |
-        pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.spatial --cov-report=xml --cov-append --disable-warnings ckanext/spatial/tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Tests
 on: pull_request
 
 jobs:
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -13,6 +14,7 @@ jobs:
         run: pip install flake8 pycodestyle
       - name: Check syntax
         run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+
   test:
     needs: lint
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: pull_request
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,15 +20,12 @@ jobs:
         include:
           - ckan-version: "2.10"
             solr-image: "2.10-spatial"
-            harvest-tag: 'v1.4.2'
             requirements-file: 'requirements.txt'
           - ckan-version: 2.9
             solr-image: 2.9-solr8-spatial
-            harvest-tag: 'v1.4.2'
             requirements-file: 'requirements.txt'
           - ckan-version: 2.9-py2
             solr-image: 2.9-py2-solr8-spatial
-            harvest-tag: 'v1.4.0'
             requirements-file: 'requirements-py2.txt'
       fail-fast: false
     
@@ -78,8 +75,8 @@ jobs:
 
     - name: Install harvester
       run: |
-        echo "Installing harvester from tag ${{ matrix.harvest-tag }}"
-        git clone --depth 1 --branch ${{ matrix.harvest-tag }} https://github.com/ckan/ckanext-harvest
+        echo "Installing harvester"
+        git clone --depth 1 https://github.com/ckan/ckanext-harvest
         cd ckanext-harvest
         echo "upgrade pip"
         pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,9 @@ Supported Versions
 ------------------
 
 ckanext-spatial >= 2.0.0 supports CKAN 2.9 and CKAN 2.10.
+Check the
+[tested enviroments](https://github.com/ckan/ckanext-spatial/blob/master/.github/workflows/test.yml)
+for more details.  
 
 For previous CKAN versions please use the v1.x tags.
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -174,7 +174,7 @@ When running the spatial harvesters
     File "xmlschema.pxi", line 102, in lxml.etree.XMLSchema.__init__ (src/lxml/lxml.etree.c:154475)
     lxml.etree.XMLSchemaParseError: local list type: A type, derived by list or union, must have the simple ur-type definition as base type, not '{http://www.opengis.net/gml}doubleList'., line 1
 
-The XSD validation used by the spatial harvesters requires libxml2 ersion 2.9.
+The XSD validation used by the spatial harvesters requires libxml2 version 2.9.
 
 With CKAN you would probably have installed an older version from your
 distribution. (e.g. with ``sudo apt-get install libxml2-dev``). You need to

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -8,3 +8,6 @@ pyparsing>=2.1.10
 requests>=1.1.0
 six
 geojson==2.5.0
+# Harvest extension install 1.3 which try to install
+# setuptools>=61.2 which is not compatible with python 2.7
+pika==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,14 +5,9 @@ pyparsing>=2.1.10
 requests>=1.1.0
 six
 
-Shapely>=1.2.13,<2.0.0; python_version < '3.9'
-Shapely==2.0.1; python_version >= '3.9'
-
 pyproj==2.6.1; python_version < '3.9'
 pyproj==3.4.1; python_version >= '3.9'
 
-OWSLib==0.18.0; python_version < '3.9'
-OWSLib==0.28.1; python_version >= '3.9'
-
-geojson==2.5.0; python_version < '3.9'
-geojson==3.0.1; python_version >= '3.9'
+Shapely==2.0.1
+OWSLib==0.28.1
+geojson==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,18 @@
 ckantoolkit
-Shapely>=1.2.13,<2.0.0
-pyproj==2.6.1
-OWSLib==0.18.0
 lxml>=2.3
 argparse
 pyparsing>=2.1.10
 requests>=1.1.0
 six
-geojson==2.5.0
+
+Shapely>=1.2.13,<2.0.0; python_version < '3.9'
+Shapely==2.0.1; python_version >= '3.9'
+
+pyproj==2.6.1; python_version < '3.9'
+pyproj==3.4.1; python_version >= '3.9'
+
+OWSLib==0.18.0; python_version < '3.9'
+OWSLib==0.28.1; python_version >= '3.9'
+
+geojson==2.5.0; python_version < '3.9'
+geojson==3.0.1; python_version >= '3.9'


### PR DESCRIPTION
Related to #301 

`pyproj==2.6.1` is not workign for Python >= 3.9

This PR starts defining proper test for each possible environment
The requirements.txt file update packages for python >= 3.9:
 - from `Shapely>=1.2.13,<2.0.0` to `Shapely==2.0.1`
 - from `pyproj==2.6.1` to `pyproj==3.4.1`
 - from `OWSLib==0.18.0` to `OWSLib==0.28.1`
 - from `geojson==2.5.0` to `geojson==3.0.1`

**Incredibly, it look like all test are green for all those new packages**
Geometries commands for the RIDL application are working fine. 

Alpine has a fixed Python version. It can not be easily changed.
You can't use Python 3.8 or 3.9 with Alpine 3.16.
We use Alpine 3.16 for CKAN 2.10 image
If we want to test this extension with CKAN 2.10 and Python 3.8 we will need a new approach.
**Should we start building CKAN 2.10 (alpine 3.16) images with Python 3.8 and Python 3.9?**

Also
 - Remove unused CKAN 2.8 and 2.7