### PR TITLE
Use csw2 from owslib

### DIFF
--- a/ckanext/spatial/lib/csw_client.py
+++ b/ckanext/spatial/lib/csw_client.py
@@ -65,7 +65,7 @@ class CswService(OwsService):
     """
     Perform various operations on a CSW service
     """
-    from owslib.csw import CatalogueServiceWeb as _Implementation
+    from owslib.catalogue.csw2 import CatalogueServiceWeb as _Implementation
 
     def __init__(self, endpoint=None):
         super(CswService, self).__init__(endpoint)
@@ -74,7 +74,7 @@ class CswService(OwsService):
     def getrecords(self, qtype=None, keywords=[],
                    typenames="csw:Record", esn="brief",
                    skip=0, count=10, outputschema="gmd", **kw):
-        from owslib.csw import namespaces
+        from owslib.catalogue.csw2 import namespaces
         constraints = []
         csw = self._ows(**kw)
 
@@ -102,7 +102,7 @@ class CswService(OwsService):
     def getidentifiers(self, qtype=None, typenames="csw:Record", esn="brief",
                        keywords=[], limit=None, page=10, outputschema="gmd",
                        startposition=0, cql=None, **kw):
-        from owslib.csw import namespaces
+        from owslib.catalogue.csw2 import namespaces
         constraints = []
         csw = self._ows(**kw)
 
@@ -154,7 +154,7 @@ class CswService(OwsService):
             kwa["startposition"] = startposition
 
     def getrecordbyid(self, ids=[], esn="full", outputschema="gmd", **kw):
-        from owslib.csw import namespaces
+        from owslib.catalogue.csw2 import namespaces
         csw = self._ows(**kw)
         kwa = {
             "esn": esn,


### PR DESCRIPTION
Fixes #310 

New owslib version has a constructor which allows building csw client for version 2.0.2 and version 3.0.0. As the csw_client is directly inherited from the old owslib csw client, this just maintains the old functionality without supporting version 3.0.0.