### PR TITLE
change str validator to unicode_safe

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -23,7 +23,7 @@ from ckan import plugins as p
 from ckan import model
 from ckan.lib.helpers import json
 from ckan import logic
-from ckan.lib.navl.validators import not_empty
+from ckan.lib.navl.validators import not_empty, unicode_safe
 from ckan.lib.search.index import PackageSearchIndex
 from ckanext.harvest.harvesters.base import munge_tag
 
@@ -646,7 +646,7 @@ class SpatialHarvester(HarvesterBase):
 
         # The default package schema does not like Upper case tags
         tag_schema = logic.schema.default_tags_schema()
-        tag_schema['name'] = [not_empty, six.text_type]
+        tag_schema['name'] = [not_empty, unicode_safe]
 
         # Flag this object as the current one
         harvest_object.current = True
@@ -660,7 +660,7 @@ class SpatialHarvester(HarvesterBase):
             # We need to explicitly provide a package ID, otherwise ckanext-spatial
             # won't be be able to link the extent to the package.
             package_dict['id'] = six.text_type(uuid.uuid4())
-            package_schema['id'] = [six.text_type]
+            package_schema['id'] = [unicode_safe]
 
             # Save reference to the package on the object
             harvest_object.package_id = package_dict['id']


### PR DESCRIPTION
### This PR replaces `six.text_type` with `unicode_safe` as validator.

`six.text_type` returns `str` for python3, using `str` as validator generates the following error seen on `v2.0.0`.

```
...
  File "/home/vcap/deps/1/src/ckanext-harvest/ckanext/harvest/queue.py", line 515, in fetch_and_import_stages
    success_import = harvester.import_stage(obj)
  File "/home/vcap/deps/1/src/ckanext-spatial/ckanext/spatial/harvesters/base.py", line 721, in import_stage
    package_id = p.toolkit.get_action('package_update')(context, package_dict)
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/logic/__init__.py", line 551, in wrapped
    result = _action(context, data_dict, **kw)
...
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/logic/__init__.py", line 551, in wrapped
    result = _action(context, data_dict, **kw)
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/logic/action/get.py", line 1085, in package_show
    package_dict, _errors = lib_plugins.plugin_validate(
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/plugins.py", line 331, in plugin_validate
    return validate(data_dict, schema, context)
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/navl/dictization_functions.py", line 305, in validate
    flat_data, errors = _validate(flattened, schema, validators_context)
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/navl/dictization_functions.py", line 356, in _validate
    convert(converter, key, converted_data, errors, context)
  File "/home/vcap/deps/1/python/lib/python3.9/site-packages/ckan/lib/navl/dictization_functions.py", line 248, in convert
    raise TypeError(
TypeError: str cannot be used as validator because it is not a user-defined function

```