### PR TITLE
detecting Microsoft-IIS server

### DIFF
--- a/ckanext/spatial/harvesters/waf.py
+++ b/ckanext/spatial/harvesters/waf.py
@@ -271,7 +271,7 @@ def _get_scraper(server):
         return 'apache'
     if 'nginx' in server.lower():
         return 'nginx'
-    if server == 'Microsoft-IIS/7.5':
+    if 'Microsoft-IIS' in server:
         return 'iis'
     else:
         return 'other'


### PR DESCRIPTION
Need this fix to scape file date from **Microsoft-IIS/10.0** server.

Base on the [IIS release history](https://learn.microsoft.com/en-us/lifecycle/products/internet-information-services-iis), 
`IIS 7.5` is on Windows 7/Windows Server 2008 R2* back to 2009. It has been `IIS 10` starting 2015.

