### PR TITLE
latest pyproj requires python 3.10, lock the version to released 3.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pyparsing>=2.1.10
 requests>=1.1.0
 cython==0.29.36; python_version < '3.9'
 pyproj==2.6.1; python_version < '3.9'
-pyproj @ git+https://github.com/pyproj4/pyproj.git@main; python_version >= '3.9'
+pyproj==3.6.1; python_version >= '3.9'
 
 Shapely==2.0.1
 OWSLib==0.28.1


### PR DESCRIPTION
Using latest from github was a workaround which now has failed if running on python 3.9, but since 3.6.1 was released, the workaround is no longer required.