### PR TITLE
Ensure the bbox input is in the correct form

### DIFF
--- a/ckanext/spatial/public/js/spatial_query.js
+++ b/ckanext/spatial/public/js/spatial_query.js
@@ -133,7 +133,7 @@ this.ckan.module('spatial-query', function ($, _) {
               map.removeLayer(module.extentLayer);
             }
             module.extentLayer = extentLayer = e.layer;
-            $('#ext_bbox').val(extentLayer.getBounds().toBBoxString());
+            module.ext_bbox_input.val(extentLayer.getBounds().toBBoxString());
             map.addLayer(extentLayer);
             element.find('.btn-primary').removeClass('disabled').addClass('btn-primary');
           });
@@ -197,33 +197,31 @@ this.ckan.module('spatial-query', function ($, _) {
 
     // Is there an existing box from a previous search?
     _setPreviousBBBox: function(map, zoom=true) {
-      previous_bbox = this._getParameterByName('ext_bbox');
+      let module = this;
+      previous_bbox = module._getParameterByName('ext_bbox');
       if (previous_bbox) {
-        $('#ext_bbox').val(previous_bbox);
-        this.extentLayer = this._drawExtentFromCoords(previous_bbox.split(','))
-        map.addLayer(this.extentLayer);
+        module.ext_bbox_input.val(previous_bbox);
+        module.extentLayer = module._drawExtentFromCoords(previous_bbox.split(','))
+        map.addLayer(module.extentLayer);
         if (zoom) {
-          map.fitBounds(this.extentLayer.getBounds(), {"animate": false, "padding": [20, 20]});
+          map.fitBounds(module.extentLayer.getBounds(), {"animate": false, "padding": [20, 20]});
         }
       } else {
-        map.fitBounds(this.options.default_extent, {"animate": false});
+        map.fitBounds(module.options.default_extent, {"animate": false});
       }
-
     },
 
     _onReady: function() {
       let module = this;
       let map;
-      let form = $(".search-form");
+      let form = $('#dataset-search-form');
+      let bbox_input_id = 'ext_bbox';
 
-      var buttons;
-
-      // Add necessary fields to the search form if not already created
-      $(['ext_bbox']).each(function(index, item){
-        if ($("#" + item).length === 0) {
-          $('<input type="hidden" />').attr({'id': item, 'name': item}).appendTo(form);
-        }
-      });
+      // Add necessary field to the search form if not already created
+      if ($("#" + bbox_input_id).length === 0) {
+        $('<input type="hidden" />').attr({'id': bbox_input_id, 'name': bbox_input_id}).appendTo(form);
+      }
+      module.ext_bbox_input = $('#dataset-search-form #ext_bbox');
 
       // OK map time
       this.mainMap = map = this._createMap('dataset-map-container');


### PR DESCRIPTION
In our particular customisation of CKAN we have 2 forms with the class of 'search-form', and this class is used to ensure styling consistency.

With the way this was set up before, both forms were getting a ext_bbox input injected into them, but then only the first one on the page was getting the bbox value set on it. This unfortunately was not the search form that actually needed the bbox value.

With these changes, I'm trying to scope the ext_bbox input to only the actual dataset search form.

In general, I think actions like this should try to target elements by ID's where possible, rather than using classes, which should be used more for defining styling to be applied to that class, but unsure what the CKAN team preferences are on this.