### PR TITLE
update map-widgets documentation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 * Dropped support for Python 2
 * Dropped support for the PostGIS search backend
-* Updated the common map JS module to support many different tile providers. The default Stamen Terrain tile will no longer work, and users will need to configure a map tiles provider. Please check the [documentation](https://docs.ckan.org/projects/ckanext-spatial/en/latest/map-widgets.html) for full details.
+* Updated the common map JS module to support many different tile providers. The default Stamen Terrain tile will no longer work, and users will need to configure a map tiles provider. Please check the [documentation](https://docs.ckan.org/projects/ckanext-spatial/en/latest/map-widgets/) for full details.
 * Upgrade tests to check all envs, including CKAN 2.10 with Python 3.10 [#308](https://github.com/ckan/ckanext-spatial/pull/308)
 * TypeError when spatial is missing [#306](https://github.com/ckan/ckanext-spatial/pull/306)
 * Fix requirements [#313](https://github.com/ckan/ckanext-spatial/pull/313)

--- a/ckanext/spatial/public/js/common_map.js
+++ b/ckanext/spatial/public/js/common_map.js
@@ -85,7 +85,7 @@
           onAdd: (map) => {
             let element = document.createElement("div");
             element.className = "leaflet-control-no-provider";
-            element.innerHTML = 'No map provider set. Please check the <a href="https://docs.ckan.org/projects/ckanext-spatial/en/latest/map-widgets.html">documentation</a>';
+            element.innerHTML = 'No map provider set. Please check the <a href="https://docs.ckan.org/projects/ckanext-spatial/en/latest/map-widgets/">documentation</a>';
             return element;
           },
           onRemove: (map) => {}


### PR DESCRIPTION
When a map provider is not configured, this doc link leads to un-styled error page.
Current error link vs correct link:

`https://docs.ckan.org/projects/ckanext-spatial/en/latest/map-widgets.html`
`https://docs.ckan.org/projects/ckanext-spatial/en/latest/map-widgets/`


![image](https://github.com/user-attachments/assets/0ce84659-e5e9-4a85-a2d1-e09ffa973ab0)
