### PR TITLE
fix: add dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,16 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.9",
 ]
-dependencies = []
+dependencies = [
+    "ckantoolkit",
+    "lxml>=2.3",
+    "pyparsing>=2.1.10",
+    "requests>=1.1.0",
+    "pyproj~=3.6",
+    "OWSLib>=0.31",
+    "Shapely~=2.0",
+    "geojson~=3.1",
+]
 license = {text = "AGPL"}
 requires-python = ">=3.9"
 


### PR DESCRIPTION
Hi! :)
Python modules should be specified their dependencies in pyproject.toml (or setup.py for the old ones). In this specific case, this change simplifies the installation of the module (no need to import requirements.txt manually into a larger pyproject.toml or try to mix requirements files together).
Pinning for CI can be done with `uv export --no-hashes > requirements.txt` or similar.
It also makes easier to automatically track/handle different versions for different Python interpreters.