### PR TITLE
Python 3.13 support

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -849,7 +849,7 @@ class SpatialHarvester(HarvesterBase):
         content = response.text
 
         # Remove original XML declaration
-        content = re.sub('<\\?xml(.*)\\?>', '', content)
+        content = re.sub('<xml(.*)>', '', content)
 
         # Get rid of the BOM and other rubbish at the beginning of the file
         content = re.sub('.*?<', '<', content, 1)
@@ -872,7 +872,7 @@ class SpatialHarvester(HarvesterBase):
         if not validator:
             validator = self._get_validator()
 
-        document_string = re.sub('<\\?xml(.*)\\?>', '', document_string)
+        document_string = re.sub('<xml(.*)>', '', document_string)
 
         try:
             xml = etree.fromstring(document_string)

--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -2,8 +2,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen
 
 import re
-import cgitb
-import warnings
+import traceback
 
 import sys
 import logging
@@ -41,12 +40,7 @@ DEFAULT_VALIDATOR_PROFILES = ['iso19139']
 
 
 def text_traceback():
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        res = 'the original traceback:'.join(
-            cgitb.text(sys.exc_info()).split('the original traceback:')[1:]
-        ).strip()
-    return res
+    return "".join(traceback.format_exception(*sys.exc_info()))
 
 
 def guess_standard(content):

--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -849,7 +849,7 @@ class SpatialHarvester(HarvesterBase):
         content = response.text
 
         # Remove original XML declaration
-        content = re.sub('<\?xml(.*)\?>', '', content)
+        content = re.sub('<\\?xml(.*)\\?>', '', content)
 
         # Get rid of the BOM and other rubbish at the beginning of the file
         content = re.sub('.*?<', '<', content, 1)
@@ -872,7 +872,7 @@ class SpatialHarvester(HarvesterBase):
         if not validator:
             validator = self._get_validator()
 
-        document_string = re.sub('<\?xml(.*)\?>', '', document_string)
+        document_string = re.sub('<\\?xml(.*)\\?>', '', document_string)
 
         try:
             xml = etree.fromstring(document_string)

--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -175,7 +175,7 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
             # Save the fetch contents in the HarvestObject
             # Contents come from csw_client already declared and encoded as utf-8
             # Remove original XML declaration
-            content = re.sub('<\\?xml(.*)\\?>', '', record['xml'])
+            content = re.sub('<xml(.*)>', '', record['xml'])
 
             harvest_object.content = content.strip()
             harvest_object.save()

--- a/ckanext/spatial/harvesters/csw.py
+++ b/ckanext/spatial/harvesters/csw.py
@@ -175,7 +175,7 @@ class CSWHarvester(SpatialHarvester, SingletonPlugin):
             # Save the fetch contents in the HarvestObject
             # Contents come from csw_client already declared and encoded as utf-8
             # Remove original XML declaration
-            content = re.sub('<\?xml(.*)\?>', '', record['xml'])
+            content = re.sub('<\\?xml(.*)\\?>', '', record['xml'])
 
             harvest_object.content = content.strip()
             harvest_object.save()


### PR DESCRIPTION
Similar fixes as was done in core https://github.com/ckan/ckan/pull/9236. 

Escaped regex strings as python 3.14 was giving warnings about them. 

Did not update dependencies, at least geojson doesn't have officially compatible version 3.14, but based on my quick test, this seems to work fine without updating them. 

But this PR is anyway required to be able to install spatial with newer pythons.